### PR TITLE
Update install.sh

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -187,9 +187,6 @@ function install_kube() {
     sudo chown $(id -u):$(id -g) $HOME/.kube/config
     echo "mainMaster"
   elif [ "${type}" == "master" ]; then
-    mkdir -p $HOME/.kube
-    sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
-    sudo chown $(id -u):$(id -g) $HOME/.kube/config
     # master type
     echo "master"
   elif [ "${type}" == "worker" ]; then


### PR DESCRIPTION
master 이중화 경우, master join 이후에 kube config 설정 해줘야 함
install.sh수행 하지 않고, 코드상에서 master join 후 진행하는 걸로 수정