### PR TITLE
[mod] README 관련 이전 PR에서 누락된 내용 추가 수정

### DIFF
--- a/K8S_Master_LBNode/README.md
+++ b/K8S_Master_LBNode/README.md
@@ -145,7 +145,7 @@
 	  timeout server 1m
 	
 	frontend k8s-api
-	  bind 0.0.0.0:6443
+	  bind 0.0.0.0:MASTERPORT
 	  default_backend k8s-api
 	
 	backend k8s-api


### PR DESCRIPTION
- README의 haproxy.cfg 파일 내용 중, 6443을 MASTERPORT 변수로 대체